### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 ![](https://badge.mcpx.dev?type=server 'MCP Server')
 [![smithery badge](https://smithery.ai/badge/@GongRzhe/Langflow-DOC-QA-SERVER)](https://smithery.ai/server/@GongRzhe/Langflow-DOC-QA-SERVER)
 
+<a href="https://glama.ai/mcp/servers/@GongRzhe/Langflow-DOC-QA-SERVER">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@GongRzhe/Langflow-DOC-QA-SERVER/badge" alt="Langflow Document Q&A Server MCP server" />
+</a>
+
 A Model Context Protocol server for document Q&A powered by Langflow
 
 This is a TypeScript-based MCP server that implements a document Q&A system. It demonstrates core MCP concepts by providing a simple interface to query documents through a Langflow backend.


### PR DESCRIPTION
This PR adds a badge for the [Langflow Document Q&A Server](https://glama.ai/mcp/servers/@GongRzhe/Langflow-DOC-QA-SERVER) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@GongRzhe/Langflow-DOC-QA-SERVER">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@GongRzhe/Langflow-DOC-QA-SERVER/badge" alt="Langflow Document Q&A Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.